### PR TITLE
Add sort key to WebSocketConnections table

### DIFF
--- a/apps/api/src/infrastructure/persistence/dynamo/websocket_connection_repo.py
+++ b/apps/api/src/infrastructure/persistence/dynamo/websocket_connection_repo.py
@@ -15,6 +15,7 @@ class WebSocketConnectionRepo:
 
     Table:
       PK  : connection_id
+      SK  : streetlight_id
 
     GSI (StreetlightIndex):
       PK  : streetlight_id
@@ -110,9 +111,18 @@ class WebSocketConnectionRepo:
         Cleans up a session when a user disconnects.
         """
         try:
-            self._table.delete_item(
-                Key={"connection_id": connection_id}
+            # Query all subscriptions for this connection
+            response = self._table.query(
+                KeyConditionExpression=Key("connection_id").eq(connection_id)
             )
+            with self._table.batch_writer() as batch:
+                for item in response.get("Items", []):
+                    batch.delete_item(
+                        Key={
+                            "connection_id": item["connection_id"],
+                            "streetlight_id": item["streetlight_id"],
+                        }
+                    )
         except Exception as e:
             raise PersistenceError(
                 f"Could not remove connection: {connection_id}"

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -610,6 +610,8 @@ Resources:
       KeySchema:
         - AttributeName: connection_id
           KeyType: HASH
+        - AttributeName: streetlight_id
+          KeyType: RANGE
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -171,36 +171,40 @@ User membership record (`SK = user_id`)
 
 ---
 
+```markdown
 ### WebSocketConnections
 
 #### Purpose
-Tracks active WebSocket connections established via API Gateway. Used to fan out real-time telemetry to connected clients. Records are written on `$connect` and deleted on `$disconnect`.
+Tracks active WebSocket connections and their streetlight subscriptions established via API Gateway. Used to fan out real-time telemetry to subscribed clients. Rows are written on `subscribe` and deleted on `$disconnect`.
 
 #### Primary Key
 ```
 PK: connection_id
+SK: streetlight_id
 ```
 
-#### GSI: ByTenant
+#### GSI: StreetlightIndex
 ```
-PK: tenant_id
+PK: streetlight_id
+SK: tenant_id
 ```
 
 #### Example Item
 ```json
 {
   "connection_id": "abc123==",
+  "streetlight_id": "LW-00001",
   "tenant_id": "tenant-001",
   "user_id": "u-123",
   "connected_at": "2026-02-24T10:00:00Z",
-  "streetlight_ids": ["LW-00100"]
+  "ttl": 1780809213
 }
 ```
 
 #### Access Patterns
-- Write connection record on `$connect`
-- Delete connection record on `$disconnect`
-- Query by `tenant_id` (via GSI) to find all active connections for fanout
+- Write one row per streetlight subscription on `subscribe` action
+- Delete all rows for a `connection_id` on `$disconnect`
+- Query by `streetlight_id` + `tenant_id` (via GSI) to find all connections to broadcast to
 - Clean up stale connections when a push returns `GoneException`
 
 ---


### PR DESCRIPTION
PK-only schema caused every subscribe to overwrite the previous row, so only the last subscribed streetlight was stored per connection. New composite key (connection_id + streetlight_id) stores one row per subscription. Updated delete to batch remove all rows for a connection.