### PR TITLE
Remove record write in websocket connect handler

### DIFF
--- a/apps/api/src/application/websocket/connect.py
+++ b/apps/api/src/application/websocket/connect.py
@@ -1,34 +1,25 @@
 """
 ConnectWebSocket application use case.
-Handles the WebSocket $connect lifecycle —
-creates the connection record and persists it.
+Handles the WebSocket $connect lifecycle.
+Connection identity is validated here; subscription records
+are created per streetlight via the subscribe action.
 """
 from __future__ import annotations
 from datetime import datetime, timezone
-from typing import Protocol
 
 from domain.websocket.models import WebSocketConnection
 
 
-class WebSocketConnectionRepo(Protocol):
-    def save(self, connection: WebSocketConnection) -> None: ...
-
-
 class ConnectWebSocket:
-    def __init__(self, repo: WebSocketConnectionRepo) -> None:
-        self._repo = repo
-
     def execute(
         self,
         connection_id: str,
         tenant_id: str,
         user_id: str,
     ) -> WebSocketConnection:
-        connection = WebSocketConnection(
+        return WebSocketConnection(
             tenant_id=tenant_id,
             user_id=user_id,
             connection_id=connection_id,
             connected_at=datetime.now(timezone.utc),
         )
-        self._repo.save(connection)
-        return connection

--- a/apps/api/src/infrastructure/handlers/websocket_connect.py
+++ b/apps/api/src/infrastructure/handlers/websocket_connect.py
@@ -18,17 +18,12 @@ from functools import lru_cache
 from application.websocket.connect import ConnectWebSocket
 from domain.errors import AuthError
 from infrastructure.auth.identity import extract_websocket_identity
-from infrastructure.persistence.dynamo.websocket_connection_repo import (
-    get_websocket_connection_repo
-)
 from libs.logging import logger
 
 
 @lru_cache(maxsize=1)
 def _use_case() -> ConnectWebSocket:
-    return ConnectWebSocket(
-        repo=get_websocket_connection_repo()
-    )
+    return ConnectWebSocket()
 
 
 def handler(event: dict, context: object) -> dict:


### PR DESCRIPTION
With the new per-subscription schema, rows are created by the subscribe action not on connect. $connect no longer needs a repo or a Dynamo write, it just validates identity and returns 200.