### PR TITLE
Refactor user tenant DynamoDB keys

### DIFF
--- a/apps/api/src/infrastructure/persistence/dynamo/user_tenant_repo.py
+++ b/apps/api/src/infrastructure/persistence/dynamo/user_tenant_repo.py
@@ -10,11 +10,21 @@ from infrastructure.persistence.error import PersistenceError
 
 
 class UserTenantRepo:
-    TENANT_SK = "TENANT"
+    TENANT_SK = "TENANT#META"
+    USER_SK_PREFIX = "USER#"
 
     def __init__(self, table_name: str) -> None:
         self._db = get_dynamodb_resource()
         self._table = self._db.Table(table_name)
+
+    def _user_sk(self, user_id: str) -> str:
+        return f"{self.USER_SK_PREFIX}{user_id}"
+
+    @classmethod
+    def _strip_user_prefix(cls, user_sk: str) -> str:
+        if user_sk.startswith(cls.USER_SK_PREFIX):
+            return user_sk[len(cls.USER_SK_PREFIX):]
+        return user_sk
 
     def get_tenant(self, tenant_id: str) -> Tenant | None:
         try:
@@ -56,7 +66,7 @@ class UserTenantRepo:
     ) -> TenantUser | None:
         try:
             result = self._table.get_item(
-                Key={"tenant_id": tenant_id, "user_id": user_id}
+                Key={"tenant_id": tenant_id, "user_id": self._user_sk(user_id)}
             )
             item = result.get("Item")
             if not item:
@@ -72,7 +82,7 @@ class UserTenantRepo:
             result = self._table.query(
                 KeyConditionExpression=(
                     Key("tenant_id").eq(tenant_id)
-                    & Key("user_id").begins_with("u-")
+                    & Key("user_id").begins_with(self.USER_SK_PREFIX)
                 ),
                 Select="COUNT",
             )
@@ -88,7 +98,7 @@ class UserTenantRepo:
             kwargs = {
                 "KeyConditionExpression": (
                     Key("tenant_id").eq(tenant_id)
-                    & Key("user_id").begins_with("u-")
+                    & Key("user_id").begins_with(self.USER_SK_PREFIX)
                 )
             }
             while True:
@@ -108,7 +118,7 @@ class UserTenantRepo:
         try:
             self._table.put_item(Item={
                 "tenant_id": user.tenant_id,
-                "user_id": user.user_id,
+                "user_id": self._user_sk(user.user_id),
                 "email": user.email,
                 "role": user.role,
                 "created_at": user.created_at,
@@ -122,7 +132,7 @@ class UserTenantRepo:
     def delete_user(self, tenant_id: str, user_id: str) -> None:
         try:
             self._table.delete_item(
-                Key={"tenant_id": tenant_id, "user_id": user_id}
+                Key={"tenant_id": tenant_id, "user_id": self._user_sk(user_id)}
             )
         except ClientError as e:
             raise PersistenceError(
@@ -133,7 +143,7 @@ class UserTenantRepo:
     def _item_to_user(item: dict) -> TenantUser:
         return TenantUser(
             tenant_id=item["tenant_id"],
-            user_id=item["user_id"],
+            user_id=UserTenantRepo._strip_user_prefix(item["user_id"]),
             email=item["email"],
             role=item["role"],
             created_at=item["created_at"],

--- a/apps/api/tests/integration/test_list_commands_handler.py
+++ b/apps/api/tests/integration/test_list_commands_handler.py
@@ -50,9 +50,9 @@ def test_list_commands_through_handler_use_case_repo_and_dynamodb(
 ):
     from infrastructure.handlers.streetlights_list_commands import handler
 
-    tenant_id = "tenant-integration"
+    tenant_id = f"tenant-{uuid.uuid4()}"
     streetlight_id = f"streetlight-{uuid.uuid4()}"
-    command_id = "2026-05-26T12:00:00Z#cmd-001"
+    command_id = f"2026-05-26T12:00:00Z#cmd-{uuid.uuid4()}"
 
     downlink_table.put_item(
         Item={

--- a/apps/api/tests/integration/test_user_invite_handler.py
+++ b/apps/api/tests/integration/test_user_invite_handler.py
@@ -74,7 +74,7 @@ def test_invite_user_through_handler_use_case_repo_and_dynamodb(
     users_table.put_item(
         Item={
             "tenant_id": tenant_id,
-            "user_id": "TENANT",
+            "user_id": "TENANT#META",
             "name": "Test Tenant",
             "owner_user_ids": [owner_user_id],
             "max_users": 5,
@@ -111,7 +111,7 @@ def test_invite_user_through_handler_use_case_repo_and_dynamodb(
     saved = users_table.get_item(
         Key={
             "tenant_id": tenant_id,
-            "user_id": invited_user_id,
+            "user_id": f"USER#{invited_user_id}",
         }
     )
 

--- a/apps/api/tests/integration/test_user_list_handler.py
+++ b/apps/api/tests/integration/test_user_list_handler.py
@@ -56,7 +56,7 @@ def test_list_users_through_handler_use_case_repo_and_dynamodb(
     users_table.put_item(
         Item={
             "tenant_id": tenant_id,
-            "user_id": user_id,
+            "user_id": f"USER#{user_id}",
             "email": "test.user@example.com",
             "role": "admin",
             "created_at": "2026-05-28T12:00:00Z",

--- a/apps/api/tests/integration/test_user_remove_handler.py
+++ b/apps/api/tests/integration/test_user_remove_handler.py
@@ -70,7 +70,7 @@ def test_remove_user_through_handler_use_case_repo_and_dynamodb(
     users_table.put_item(
         Item={
             "tenant_id": tenant_id,
-            "user_id": "TENANT",
+            "user_id": "TENANT#META",
             "name": "Test Tenant",
             "owner_user_ids": [owner_user_id],
             "max_users": 5,
@@ -81,7 +81,7 @@ def test_remove_user_through_handler_use_case_repo_and_dynamodb(
     users_table.put_item(
         Item={
             "tenant_id": tenant_id,
-            "user_id": remove_user_id,
+            "user_id": f"USER#{remove_user_id}",
             "email": "remove.user@example.com",
             "role": "operator",
             "created_at": "2026-05-28T12:05:00Z",
@@ -113,7 +113,7 @@ def test_remove_user_through_handler_use_case_repo_and_dynamodb(
     saved = users_table.get_item(
         Key={
             "tenant_id": tenant_id,
-            "user_id": remove_user_id,
+            "user_id": f"USER#{remove_user_id}",
         }
     )
 

--- a/apps/api/tests/integration/test_user_update_handler.py
+++ b/apps/api/tests/integration/test_user_update_handler.py
@@ -56,7 +56,7 @@ def test_update_user_name_through_handler_use_case_repo_and_dynamodb(
     users_table.put_item(
         Item={
             "tenant_id": tenant_id,
-            "user_id": "TENANT",
+            "user_id": "TENANT#META",
             "name": "Test Tenant",
             "owner_user_ids": [owner_user_id],
             "max_users": 5,
@@ -67,7 +67,7 @@ def test_update_user_name_through_handler_use_case_repo_and_dynamodb(
     users_table.put_item(
         Item={
             "tenant_id": tenant_id,
-            "user_id": update_user_id,
+            "user_id": f"USER#{update_user_id}",
             "name": "Old Name",
             "email": "update.user@example.com",
             "role": "operator",
@@ -107,7 +107,7 @@ def test_update_user_name_through_handler_use_case_repo_and_dynamodb(
     saved = users_table.get_item(
         Key={
             "tenant_id": tenant_id,
-            "user_id": update_user_id,
+            "user_id": f"USER#{update_user_id}",
         }
     )
 


### PR DESCRIPTION
Refactored UserTenant DynamoDB key format.

Changes:
- Changed tenant metadata key from TENANT to TENANT#META
- Changed user keys to USER#user_id
- Added helper logic to strip USER# before returning API response
- Updated integration tests for new key format
- Fixed command history test to use unique IDs

Local checks passed:
- flake8
- 347 tests